### PR TITLE
feat(llm): implement automated draft reply generation (#26)

### DIFF
--- a/src/recruiter_auto_respond/llm_client.py
+++ b/src/recruiter_auto_respond/llm_client.py
@@ -2,6 +2,7 @@ import asyncio
 import base64
 import json
 import logging
+from typing import Any
 
 import httpx
 from tenacity import (
@@ -31,7 +32,7 @@ def _is_transient_error(exception: BaseException) -> bool:
 
 
 class LLMClient:
-    """Client for classification using a local LLM (e.g., llama.cpp)."""
+    """Client for LLM operations using a local server (e.g., llama.cpp)."""
 
     def __init__(self, api_url: str, api_key: str = "sk-no-key-required") -> None:
         """Initialize the LLM client.
@@ -46,7 +47,7 @@ class LLMClient:
         self.api_key = api_key
         self.semaphore = asyncio.Semaphore(settings.PARALLEL_LIMIT)
         self.client = httpx.AsyncClient(timeout=60.0)
-        self.system_prompt = (
+        self.classification_system_prompt = (
             "You are an expert recruitment assistant. Analyze the "
             "email content provided.\n"
             "Determine if it is a message from a recruiter, hiring manager, or "
@@ -57,6 +58,16 @@ class LLMClient:
             "INCLUDE: Personalized outreach, requests for your resume, or "
             "invitations to interview.\n\n"
             'Respond ONLY with a JSON object: {"is_recruiter": true/false}'
+        )
+        self.reply_system_prompt = (
+            "You are a professional software engineer with a focus on senior backend "
+            "and infrastructure roles. Draft a concise, polite reply to the "
+            "recruiter email provided.\n"
+            "Express interest in learning more about the role and suggest a brief "
+            "sync if the role aligns with a senior backend/infrastructure focus.\n"
+            "Keep the tone helpful but firm on scope.\n"
+            "Respond ONLY with the text of the reply.\n"
+            "Do NOT include a signature or a subject line."
         )
 
     async def close(self) -> None:
@@ -76,7 +87,6 @@ class LLMClient:
             return {"Authorization": f"Basic {encoded_auth}"}
 
         # Use provided api_key or fall back to settings
-        # In tests, sk-no-key-required is the default value passed to __init__
         token = self.api_key
         if not token or token == "sk-no-key-required":
             token = getattr(settings, "LLM_API_KEY", "sk-no-key-required")
@@ -89,41 +99,80 @@ class LLMClient:
         retry=retry_if_exception(_is_transient_error),
         reraise=True,
     )
-    async def _call_llm(self, body: str) -> bool:
-        """Internal method to call the LLM API with retries.
+    async def _request_llm(
+        self,
+        system_prompt: str,
+        user_content: str,
+        response_format: dict[str, Any] | None = None,
+        temperature: float = 0.1,
+    ) -> str | None:
+        """Internal method to call the LLM API with retries and semaphore.
+
+        Args:
+            system_prompt: The system prompt to use.
+            user_content: The user content (email body).
+            response_format: Optional JSON schema or type.
+            temperature: Sampling temperature.
+
+        Returns:
+            The raw text content of the LLM response, or None if it fails.
+        """
+        async with self.semaphore:
+            # Simple character-based truncation to stay within context limits
+            max_context = getattr(settings, "LLM_MAX_CONTEXT", 70000)
+            truncated_body = user_content[:max_context]
+            url = self.api_url.join("chat/completions")
+
+            logging.info("Posting to %s", url)
+            payload = {
+                "model": getattr(settings, "LLM_MODEL_NAME", "gpt-3.5-turbo"),
+                "messages": [
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": truncated_body},
+                ],
+                "temperature": temperature,
+            }
+            if response_format:
+                payload["response_format"] = response_format
+
+            response = await self.client.post(
+                url,
+                headers=self._get_headers(),
+                json=payload,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            try:
+                content = data["choices"][0]["message"]["content"]
+                if isinstance(content, str):
+                    return content
+                return None
+            except (KeyError, IndexError) as e:
+                logging.error("Failed to parse LLM response: %s", e)
+                return None
+
+    async def classify_message(self, body: str) -> bool:
+        """Determine if a message is from a recruiter.
 
         Args:
             body: The email body content to classify.
 
         Returns:
-            True if the message is from a recruiter, False otherwise.
+            True if identified as a recruiter, False otherwise.
         """
-        # Simple character-based truncation to stay within context limits
-        max_context = getattr(settings, "LLM_MAX_CONTEXT", 70000)
-        truncated_body = body[:max_context]
-        url = self.api_url.join("chat/completions")
-
-        logging.info("Posting to %s", url)
-        response = await self.client.post(
-            url,
-            headers=self._get_headers(),
-            json={
-                "model": getattr(settings, "LLM_MODEL_NAME", "gpt-3.5-turbo"),
-                "messages": [
-                    {"role": "system", "content": self.system_prompt},
-                    {"role": "user", "content": truncated_body},
-                ],
-                "response_format": {"type": "json_object"},
-                "temperature": 0.1,
-            },
-        )
-        response.raise_for_status()
-        data = response.json()
-
+        logging.info("Classifying message with LLM...")
         try:
-            content = data["choices"][0]["message"]["content"]
+            content = await self._request_llm(
+                system_prompt=self.classification_system_prompt,
+                user_content=body,
+                response_format={"type": "json_object"},
+                temperature=0.1,
+            )
+            if not content:
+                return False
+
             result = json.loads(content)
-            # Handle both possible keys from different prompts
             is_recruiter = result.get("is_recruiter") or result.get("isRecruiter")
 
             if not isinstance(is_recruiter, bool):
@@ -134,27 +183,30 @@ class LLMClient:
                 return False
 
             return is_recruiter
-        except (KeyError, IndexError, json.JSONDecodeError) as e:
-            logging.error("Failed to parse LLM response: %s", e)
+        except Exception as e:
+            logging.error("LLM classification failed after retries: %s", e)
             return False
 
-    async def classify_message(self, body: str) -> bool:
-        """Determine if a message is from a recruiter.
-
-        This method uses a semaphore to limit parallel requests and
-        handles retries internally via `_call_llm`.
+    async def generate_reply(self, body: str) -> str | None:
+        """Generate a professional draft reply to a recruiter email.
 
         Args:
-            body: The email body content to classify.
+            body: The email body content.
 
         Returns:
-            True if the message is identified as being from a recruiter,
-            False otherwise. Returns False if all retries fail.
+            The generated reply text, or None if generation fails.
         """
-        logging.info("Classifying message with LLM...")
-        async with self.semaphore:
-            try:
-                return await self._call_llm(body)
-            except Exception as e:
-                logging.error("LLM classification failed after retries: %s", e)
-                return False
+        logging.info("Generating draft reply with LLM...")
+        try:
+            content = await self._request_llm(
+                system_prompt=self.reply_system_prompt,
+                user_content=body,
+                temperature=0.7,
+            )
+            if isinstance(content, str):
+                return content
+            return None
+        except Exception as e:
+            logging.error("LLM reply generation failed after retries: %s", e)
+            return None
+

--- a/src/recruiter_auto_respond/main.py
+++ b/src/recruiter_auto_respond/main.py
@@ -63,6 +63,19 @@ async def classify_and_record(
         is_recruiter = await clients.llm.classify_message(body)
 
         if is_recruiter:
+            # Generate draft reply
+            draft_reply = await clients.llm.generate_reply(body)
+            if draft_reply:
+                logger.info(
+                    "Generated draft reply for message %s: %s...",
+                    message_id,
+                    draft_reply[:50].replace("\n", " "),
+                )
+            else:
+                logger.warning(
+                    "Failed to generate draft reply for message %s.", message_id
+                )
+
             if not dry_run:
                 await clients.gmail.add_label(message_id, clients.label_id)
                 logger.info(f"Labeled message {message_id} as Recruiter.")
@@ -74,6 +87,7 @@ async def classify_and_record(
                 "threadId": thread_id,
                 "messageId": message_id,
                 "timestamp": msg_ts_iso,
+                "draftReply": draft_reply,
             }
             return row, True
 

--- a/src/recruiter_auto_respond/main.py
+++ b/src/recruiter_auto_respond/main.py
@@ -135,7 +135,8 @@ async def run_pipeline(
         if filtered_rows:
             logger.info(f"Syncing {len(filtered_rows)} rows to Sheets.")
             sync_data = [
-                [r["threadId"], r["messageId"], r["timestamp"]] for r in filtered_rows
+                [r["threadId"], r["messageId"], r["timestamp"], r.get("draftReply", "")]
+                for r in filtered_rows
             ]
             await clients.sheets.append_rows(settings.GOOGLE_SHEET_ID, sync_data)
         else:

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -109,12 +109,39 @@ async def test_retry_on_failure(
     # Directly patch the wait configuration of the decorated function's retry object.
     # The @retry decorator is evaluated at import, so monkeypatching wait_exponential
     # at the module level doesn't affect it.
-    monkeypatch.setattr(llm_client._call_llm.retry, "wait", wait_none())
+    monkeypatch.setattr(llm_client._request_llm.retry, "wait", wait_none())
 
     result = await llm_client.classify_message("Hello")
     assert result is True
     expected_call_count = 3
     assert route.call_count == expected_call_count
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_generate_reply_success(llm_client: LLMClient) -> None:
+    respx.post("http://localhost:8080/v1/chat/completions").mock(
+        return_value=Response(
+            200,
+            json={
+                "choices": [{"message": {"content": "I am interested in this role."}}]
+            },
+        )
+    )
+
+    result = await llm_client.generate_reply("Recruiter email body")
+    assert result == "I am interested in this role."
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_generate_reply_failure(llm_client: LLMClient) -> None:
+    respx.post("http://localhost:8080/v1/chat/completions").mock(
+        return_value=Response(500)
+    )
+
+    result = await llm_client.generate_reply("Recruiter email body")
+    assert result is None
 
 
 @respx.mock

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -183,10 +183,16 @@ async def test_generate_reply_success(llm_client: LLMClient) -> None:
 
 @respx.mock
 @pytest.mark.asyncio
-async def test_generate_reply_failure(llm_client: LLMClient) -> None:
+async def test_generate_reply_failure(
+    llm_client: LLMClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
     respx.post("http://localhost:8080/v1/chat/completions").mock(
         return_value=Response(500)
     )
+
+    # Disable Tenacity backoff so this failure-path unit test stays fast
+    # and deterministic while still exercising the retry logic.
+    monkeypatch.setattr(llm_client._retry_config, "wait", wait_none())
 
     result = await llm_client.generate_reply("Recruiter email body")
     assert result is None

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -81,7 +81,18 @@ async def test_main_pipeline_success():
             mock_llm.generate_reply.assert_called_once_with("Recruiter email body")
             mock_gmail.add_label.assert_called_once_with("msg1", "label_id")
             mock_sheets.get_message_ids.assert_called_once_with("sheet_id")
+
+            # Verify the row data passed to append_rows
             mock_sheets.append_rows.assert_called_once()
+            call_args = mock_sheets.append_rows.call_args
+            assert call_args[0][0] == "sheet_id"
+            sync_data = call_args[0][1]
+            assert len(sync_data) == 1
+            row = sync_data[0]
+            assert row[0] == "t1"  # Thread ID
+            assert row[1] == "msg1"  # Message ID
+            assert row[3] == "Draft reply"  # Draft Reply
+
             mock_state_manager.update_watermark.assert_called_once()
             mock_llm.close.assert_called_once()
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -237,3 +237,80 @@ async def test_main_pipeline_success() -> None:
 
         mock_state_manager.update_watermark.assert_called_once()
         mock_llm.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_main_pipeline_dry_run() -> None:
+    """Test the pipeline in dry-run mode."""
+
+    # Mock settings
+    with patch("recruiter_auto_respond.main.settings") as mock_settings:
+        mock_settings.GMAIL_LABEL_NAME = "recruiter"
+        mock_settings.GOOGLE_SHEET_ID = "sheet_id"
+        mock_settings.PARALLEL_LIMIT = 5
+        mock_settings.LLM_API_URL = "http://llm"
+        mock_settings.LLM_API_KEY = "key"
+        mock_settings.STATE_FILE = "state.json"
+
+        # Mock StateManager
+        mock_state_manager = MagicMock()
+        mock_state_manager.load_state = AsyncMock(
+            return_value=AppState(last_run_timestamp="2023-01-01T00:00:00.000Z")
+        )
+        mock_state_manager.update_watermark = AsyncMock(
+            return_value="2023-01-01T01:00:00.000Z"
+        )
+
+        # Mock Clients
+        mock_gmail = AsyncMock()
+        mock_sheets = AsyncMock()
+        mock_llm = AsyncMock()
+        mock_llm.close = AsyncMock()
+
+        # 1. Mock Gmail: fetch_messages
+        mock_gmail.fetch_messages.return_value = [{"id": "msg1", "threadId": "t1"}]
+
+        # 2. Mock Gmail: fetch_message_metadata
+        mock_gmail.fetch_message_metadata.return_value = {
+            "id": "msg1",
+            "threadId": "t1",
+            "internalDate": str(
+                int(
+                    datetime(2023, 1, 1, 1, 0, 0, tzinfo=timezone.utc).timestamp()
+                    * 1000
+                )
+                + 100
+            ),
+        }
+
+        # 3. Mock Gmail: get_or_create_label
+        mock_gmail.get_or_create_label.return_value = "label_id"
+
+        # 4. Mock Gmail: fetch_message_body
+        mock_gmail.fetch_message_body.return_value = "Recruiter email body"
+
+        # 5. Mock LLM: classify_message
+        mock_llm.classify_message.return_value = True
+        mock_llm.generate_reply.return_value = "Dry run reply"
+
+        # Patch all components
+        with patch(
+            "recruiter_auto_respond.main.setup_clients",
+            return_value=(mock_gmail, mock_sheets, mock_llm, mock_state_manager),
+        ), patch(
+            "argparse.ArgumentParser.parse_args",
+            return_value=MagicMock(dry_run=True),
+        ):
+            await main()
+
+            # Verify interactions
+            mock_gmail.fetch_messages.assert_called_once()
+            mock_llm.classify_message.assert_called_once()
+            mock_llm.generate_reply.assert_called_once()
+            # label should NOT be added in dry run
+            mock_gmail.add_label.assert_not_called()
+            # sheets should NOT be touched in dry run
+            mock_sheets.get_message_ids.assert_not_called()
+            mock_sheets.append_rows.assert_not_called()
+            mock_state_manager.update_watermark.assert_called_once()
+            mock_llm.close.assert_awaited_once()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -58,6 +58,7 @@ async def test_main_pipeline_success():
 
         # 5. Mock LLM: classify_message
         mock_llm.classify_message.return_value = True
+        mock_llm.generate_reply.return_value = "Draft reply"
 
         # 6. Mock Sheets: get_message_ids
         mock_sheets.get_message_ids.return_value = set()
@@ -77,6 +78,7 @@ async def test_main_pipeline_success():
             # Verify interactions
             mock_gmail.fetch_messages.assert_called_once()
             mock_llm.classify_message.assert_called_once_with("Recruiter email body")
+            mock_llm.generate_reply.assert_called_once_with("Recruiter email body")
             mock_gmail.add_label.assert_called_once_with("msg1", "label_id")
             mock_sheets.get_message_ids.assert_called_once_with("sheet_id")
             mock_sheets.append_rows.assert_called_once()


### PR DESCRIPTION
Closes #26. Implement LLM-based draft reply generation for recruiter emails.

### Changes:
- **Refactored `LLMClient`**: Centralized LLM requests in a generic `_request_llm` method with shared semaphore, retry logic, and error handling.
- **Implemented `generate_reply`**: Added a new method to generate professional draft replies using a specialized system prompt for senior backend/infrastructure engineers. Responses are returned as raw text per design review feedback.
- **Pipeline Integration**: Updated `classify_and_record` in `main.py` to call `generate_reply` when a recruiter is identified and store the result in the message metadata.
- **Tests**: Added unit tests for `generate_reply` and updated existing tests to verify the new pipeline flow.