### PR TITLE
chore: add .geminiignore to expose HANDOFF.md to AI context

### DIFF
--- a/.geminiignore
+++ b/.geminiignore
@@ -1,0 +1,2 @@
+# Include HANDOFF.md even if it's in .gitignore
+!HANDOFF.md


### PR DESCRIPTION
This PR adds a .geminiignore file to explicitly un-ignore HANDOFF.md for Gemini CLI and other AI agents. This allows the agents to access the coordination file while it remains in .gitignore to prevent accidental commits to the repository.

This branch is now correctly based on `main`.